### PR TITLE
Use the release download link instead of master branch and other fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "a320nx-website",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a320nx-website",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/about/About.js
+++ b/src/about/About.js
@@ -18,7 +18,7 @@ const About = () => (
         </div>
         <div className="row justify-content-center pad-top">
             <ul>
-                <li>Our <a href="https://www.github.com/wpine215/msfs-a320neo">github page</a> has been visited over 35,000 times since then.</li>
+                <li>Our <a href="https://github.com/flybywiresim/a32nx">github page</a> has been visited over 35,000 times since then.</li>
                 <li>Over 300 commits have been made since Microsoft Flight Simulator released on August 18th, 2020</li>
                 <li>On August 22nd, 2020, we successfully released v0.1.1 of the A320 realism mod.</li>
                 <li>More than 20 systems have already been modified and brought up to a functional state</li>

--- a/src/installation/A32NXInstallInstructions.js
+++ b/src/installation/A32NXInstallInstructions.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {a32nxStableDownloadUrl} from '../utils/constants';
 
 const A32NXInstallInstructions = () => (
     <div className="pad-top container">
@@ -9,9 +10,6 @@ const A32NXInstallInstructions = () => (
             <span className="danger">
                 <div className="text-center">**WARNING**:</div>
                 <div className="text-center">
-                    Use the pre-release build at your own risk, it can be very unstable. Some features may be incomplete or not function properly.
-                </div>
-                <div className="text-center">
                     WE ARE NOT RESPONSIBLE IF YOUR SIMULATOR BREAKS.
                 </div>
             </span>
@@ -19,7 +17,7 @@ const A32NXInstallInstructions = () => (
         <br />
         <div className="row justify-content-center pad-top">
             <div className="col-lg-8 text-center">
-                <h5 className="instruction-step">Step 1. Download either the <a href={process.env.REACT_APP_STABLE_URL} className="link-text-stable">Stable</a> or <a href={process.env.REACT_APP_PRE_RELEASE_URL} className="link-text-pre">Pre-Release</a> build.</h5>
+                <h5 className="instruction-step">Step 1. Download the <a href={a32nxStableDownloadUrl} className="link-text-stable">Stable</a> build.</h5>
             </div>
         </div>
         <div className="row justify-content-center pad-top-large">
@@ -30,16 +28,30 @@ const A32NXInstallInstructions = () => (
                     <div className="row justify-content-center">
                         <div className="card border-primary mb-3" style={{ "width": "80%" }}>
                             <div className="card-body">
-                                <h4 className="card-title">Microsoft Store</h4>
-                                <p className="card-text">C:/Users/&lt;name&gt;/Appdata/Local/Packages/Microsoft.FlightSimulator_&lt;random&gt;/LocalCache/Packages/</p>
+                                <h4 className="card-title">Microsoft Store or Game Pass</h4>
+                                <p className="card-text">
+                                    {'C:\\Users\\[YOUR USERNAME]\\AppData\\Local\\Packages\\Microsoft.FlightSimulator_<RANDOMLETTERS>\\LocalCache\\Packages\\Community'}
+                                </p>
                             </div>
                         </div>
                     </div>
-	                <div className="row justify-content-center">
-                        <div className="card border-primary mb-3" style={{ "width": "80%" }}>
+                    <div className="row justify-content-center">
+                        <div className="card border-primary mb-3" style={{"width": "80%"}}>
                             <div className="card-body">
                                 <h4 className="card-title">Steam</h4>
-                                <p className="card-text">C:/Program Files(x86)/Steam/steamapps/common/Microsoft Flight Simulator/</p>
+                                <p className="card-text">
+                                    {'C:\\Users\\[YOUR USERNAME]\\AppData\\Roaming\\Microsoft Flight Simulator\\Packages\\Community'}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="row justify-content-center">
+                        <div className="card border-primary mb-3" style={{"width": "80%"}}>
+                            <div className="card-body">
+                                <h4 className="card-title">Boxed edition</h4>
+                                <p className="card-text">
+                                    {'C:\\Users\\[YOUR USERNAME]\\AppData\\Local\\MSFSPackages\\Community'}
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -48,8 +60,7 @@ const A32NXInstallInstructions = () => (
         </div>
         <div className="row justify-content-center pad-top">
             <div className="col-lg-8 text-center">
-                <h5 className="instruction-step">Step 3. Copy and paste ONLY the "A32NX" folder from the zip file into your "Community" folder.</h5>
-                <p><span className="danger">*</span>This is very important. If you paste the entire zip file contents into the folder, the mod will not work.<span className="danger">*</span></p>
+                <h5 className="instruction-step">Step 3. Copy and paste the "A32NX" folder from the zip file into your "Community" folder.</h5>
             </div>
         </div>
     </div>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,13 +1,12 @@
+export const a32nxStableDownloadUrl = "https://github.com/flybywiresim/a32nx/releases/latest/download/flybywiresim-a32nx.zip";
+
 export const releases = [
     {
         name: "A32NX",
         logoUrl: "logos/logo_wide_transparent.png",
         release_types: {
             stable: {
-                url: process.env.REACT_APP_STABLE_URL,
-            },
-            preRelease: {
-                url: process.env.REACT_APP_PRE_RELEASE_URL,
+                url: a32nxStableDownloadUrl,
             }
         },
         instructionLink: "/a32nx",


### PR DESCRIPTION
Fixes the github link in about page to point to new repo.

Changed stable build link to point to the latest github release download, which is a zip with only the A32NX folder inside, and the url will never need to be changed.

Removed the pre release build because it is currently older than the stable version.

Fixed install folder paths and added path for Boxed edition.