### PR TITLE
A32NX Installation page redesign

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -157,3 +157,9 @@ only screen and (max-width: 760px),
 .test {
   visibility: visible;
 }
+
+code {
+  color: #666;
+  background-color: #e4e4e4;
+  border: solid 4px #e4e4e4;
+}

--- a/src/installation/A32NXInstallInstructions.js
+++ b/src/installation/A32NXInstallInstructions.js
@@ -7,68 +7,86 @@ const A32NXInstallInstructions = () => (
         <div className="row justify-content-center">
             <img className="margin-right-5 install-logo" src={require("../logos/flybywire-huge.png")} alt="flybywire-logo"/>
         </div>
-        <div className="justify-content-center pad-top container">
-            <span className="danger">
-                <div className="text-center">**WARNING**:</div>
-                <div className="text-center">
+        <div className="row justify-content-center">
+            <div className="col-lg-8 alert alert-danger text-center">
+                <p>WARNING</p>
+                <p>
                     WE ARE NOT RESPONSIBLE IF YOUR SIMULATOR BREAKS.
-                </div>
-            </span>
-        </div>
-        <br />
-        <div className="row justify-content-center pad-top">
-            <div className="col-lg-8 text-center">
-                <h5 className="instruction-step">You can download the <a href={a32nxInstaller} className="link-text-stable">installer</a> or follow the instructions below.</h5>
+                </p>
             </div>
         </div>
-        <br />
-        <div className="row justify-content-center pad-top">
-            <div className="col-lg-8 text-center">
-                <h5 className="instruction-step">Step 1. Download the <a href={a32nxStableDownloadUrl} className="link-text-stable">Stable</a> build.</h5>
+        <div className="row pad-top justify-content-center">
+            <div className="col-lg-8">
+                <p>There are two ways of installing the A32NX:</p>
             </div>
         </div>
-        <div className="row justify-content-center pad-top-large">
-            <div className="col-lg-8 text-center">
-                <h5 className="instruction-step">Step 2. Navigate to your game directory, then double click on the <strong>"Community"</strong> folder.</h5>
-                <div className="instruction-step">
+        <div className="row pad-top justify-content-center">
+            <div className="col-lg-8 ">
+                <h3 className="instruction-step">Option 1.</h3>
+                <p className="instruction-step">Download the <a href={a32nxInstaller} className="link-text-stable">installer</a></p>
+            </div>
+        </div>
+        <div className="row pad-top justify-content-center">
+            <div className="col-lg-8">
+                <h3 className="instruction-step">Option 2.</h3>
+                <p className="instruction-step">Manual installation:</p>
+            </div>
+            <div className="col-lg-8">
+                <h5 className="instruction-step">Step 1.</h5>
+                <p>Download the <a href={a32nxStableDownloadUrl} className="link-text-stable">Stable</a> build.</p>
+            </div>
+            <div className="col-lg-8">
+                <h5 className="instruction-step">Step 2.</h5>
+                <p>Navigate to your game directory, then double click on the <code>Community</code> folder:</p>
+                <div className="instruction-step pb-3">
                     <h6 className="pad-top">Default install directories:</h6>
                     <div className="row justify-content-center">
-                        <div className="card border-primary mb-3" style={{ "width": "80%" }}>
-                            <div className="card-body">
-                                <h4 className="card-title">Microsoft Store or Game Pass</h4>
-                                <p className="card-text">
-                                    {'C:\\Users\\[YOUR USERNAME]\\AppData\\Local\\Packages\\Microsoft.FlightSimulator_<RANDOMLETTERS>\\LocalCache\\Packages\\Community'}
-                                </p>
+                        <div className="col">
+                            <div className="card border-primary mb-3">
+                                <div className="card-body">
+                                    <h4 className="card-title">Microsoft Store or Game Pass</h4>
+                                    <p className="card-text">
+                                        {'C:\\Users\\[YOUR USERNAME]\\AppData\\Local\\Packages\\Microsoft.FlightSimulator_<RANDOMLETTERS>\\LocalCache\\Packages\\Community'}
+                                    </p>
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div className="row justify-content-center">
-                        <div className="card border-primary mb-3" style={{"width": "80%"}}>
-                            <div className="card-body">
-                                <h4 className="card-title">Steam</h4>
-                                <p className="card-text">
-                                    {'C:\\Users\\[YOUR USERNAME]\\AppData\\Roaming\\Microsoft Flight Simulator\\Packages\\Community'}
-                                </p>
+                        <div className="col">
+                            <div className="card border-primary mb-3">
+                                <div className="card-body">
+                                    <h4 className="card-title">Steam</h4>
+                                    <p className="card-text">
+                                        {'C:\\Users\\[YOUR USERNAME]\\AppData\\Roaming\\Microsoft Flight Simulator\\Packages\\Community'}
+                                    </p>
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div className="row justify-content-center">
-                        <div className="card border-primary mb-3" style={{"width": "80%"}}>
-                            <div className="card-body">
-                                <h4 className="card-title">Boxed edition</h4>
-                                <p className="card-text">
-                                    {'C:\\Users\\[YOUR USERNAME]\\AppData\\Local\\MSFSPackages\\Community'}
-                                </p>
+                        <div className="col">
+                            <div className="card border-primary mb-3">
+                                <div className="card-body">
+                                    <h4 className="card-title">Boxed edition</h4>
+                                    <p className="card-text">
+                                        {'C:\\Users\\[YOUR USERNAME]\\AppData\\Local\\MSFSPackages\\Community'}
+                                    </p>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-        <div className="row justify-content-center pad-top">
-            <div className="col-lg-8 text-center">
-                <h5 className="instruction-step">Step 3. Copy and paste the "A32NX" folder from the zip file into your "Community" folder. The A320neo inside FS2020 will be replaced by A32NX. If you wish to revert back to the original one, you can simply delete this folder.</h5>
+            <div className="col-lg-8">
+                <h5 className="instruction-step">Step 3.</h5>
+                <p>Copy and paste the "A32NX" folder from the zip file into your "Community" folder.</p>
+                <p>The A320neo inside FS2020 will be replaced by A32NX. If you wish to revert back to the original one, you can simply delete this folder.</p>
             </div>
+        </div>
+
+        <div className="row justify-content-center pad-top">
+
         </div>
     </div>
 );


### PR DESCRIPTION
This PR redesigns a bit of the install page to give a better text flow, and improve readability both in desktop and mobile versions of the page.

Things that have changed:

- Aligned text to the left, giving a better text flow over a step by step instruction
- Separated titles from paragraphs (Basically separating "Step #" from the description of the step)
  - This improves creates a hierarchy between title and descriptions
  - This means that the descriptions are not in all-caps anymore, improving readability as well
- Put the warning banner inside a bootstrap alert, so it looks nicer
- Made all columns a `col-lg-8` for consistency
- Made it clear that the installer and manual installations are 2 separate ways of achieving the same thing, by putting them inside `Option 1` and `Option 2` titles.
- Grouped all steps in a single `row` bootstrap element, separating each step by a `col`, which means there are less divs overall

# Desktop
## Before
![image](https://user-images.githubusercontent.com/23201434/97204990-927a8100-1795-11eb-8e1d-6640c3b4b1ec.png)

## After
![image](https://user-images.githubusercontent.com/23201434/97204949-868ebf00-1795-11eb-9cb9-24800ede8ae5.png)

# Mobile
## Before
![image](https://user-images.githubusercontent.com/23201434/97205138-cfdf0e80-1795-11eb-8374-f777f665513f.png)

## After
![image](https://user-images.githubusercontent.com/23201434/97205109-c2c21f80-1795-11eb-8c9b-1bf682b86727.png)
