### PR TITLE
feat: add button hover states

### DIFF
--- a/src/components/app/Download.tsx
+++ b/src/components/app/Download.tsx
@@ -36,7 +36,7 @@ export function Download(): JSX.Element {
                                 <span className="text-4xl text-blue-100">Installer</span>
                                 <p className="mt-4 mb-6">Our easy-to-use installer is the easiest way to get started with our addons. Simply launch and install any addon you want, with only two clicks.</p>
                                 <a href="https://api.flybywiresim.com/installer">
-                                    <Button className="w-40 float-right bg-green-500 font-bold">Download</Button>
+                                    <Button className="w-40 float-right bg-green-500 hover:bg-green-600 font-bold">Download</Button>
                                 </a>
                             </div>
                             <div className="pt-5">
@@ -47,19 +47,19 @@ export function Download(): JSX.Element {
                                     <div className="flex flex-row justify-between items-center mb-5">
                                         <span className="text-xl text-gray-300">Stable release</span>
                                         <a href={getDownloadLink(urls.stable)}>
-                                            <Button className="w-40 float-right bg-green-500 font-bold">Download</Button>
+                                            <Button className="w-40 float-right bg-green-500 hover:bg-green-600 font-bold">Download</Button>
                                         </a>
                                     </div>
                                     <div className="flex flex-row justify-between items-center mb-5 pt-5">
                                         <span className="text-xl text-gray-300">Development build</span>
                                         <a href={getDownloadLink(urls.dev)}>
-                                            <Button className="w-40 float-right bg-blue-700 font-bold">Download</Button>
+                                            <Button className="w-40 float-right bg-blue-700 hover:bg-blue-800 font-bold">Download</Button>
                                         </a>
                                     </div>
                                     <div className="flex flex-row justify-between items-center mb-8 pt-5">
                                         <span className="text-xl text-gray-300">Custom fly-by-wire build</span>
                                         <a href={getDownloadLink(urls.cfbw)}>
-                                            <Button className="w-40 float-right bg-blue-700 font-bold">Download</Button>
+                                            <Button className="w-40 float-right bg-blue-700 hover:bg-blue-800 font-bold">Download</Button>
                                         </a>
                                     </div>
                                 </div>


### PR DESCRIPTION
I added hover states to the buttons on the downloads section.

HOVER:
![Screenshot_1](https://user-images.githubusercontent.com/70278701/107411790-f32b9080-6adc-11eb-9433-272455669b8b.png)

NO HOVER:
![Screenshot_2](https://user-images.githubusercontent.com/70278701/107411816-f9ba0800-6adc-11eb-9c5c-dca589e976a5.png)
