### PR TITLE
fix: downloads grammer fix

### DIFF
--- a/src/components/app/Download.tsx
+++ b/src/components/app/Download.tsx
@@ -45,19 +45,19 @@ export function Download(): JSX.Element {
 
                                 <div className="divide-y divide-gray-700">
                                     <div className="flex flex-row justify-between items-center mb-5">
-                                        <span className="text-xl text-gray-300">Stable release</span>
+                                        <span className="text-xl text-gray-300">Stable Release</span>
                                         <a href={getDownloadLink(urls.stable)}>
                                             <Button className="w-40 float-right bg-green-500 hover:bg-green-600 font-bold">Download</Button>
                                         </a>
                                     </div>
                                     <div className="flex flex-row justify-between items-center mb-5 pt-5">
-                                        <span className="text-xl text-gray-300">Development build</span>
+                                        <span className="text-xl text-gray-300">Development Build</span>
                                         <a href={getDownloadLink(urls.dev)}>
                                             <Button className="w-40 float-right bg-blue-700 hover:bg-blue-800 font-bold">Download</Button>
                                         </a>
                                     </div>
                                     <div className="flex flex-row justify-between items-center mb-8 pt-5">
-                                        <span className="text-xl text-gray-300">Custom fly-by-wire build</span>
+                                        <span className="text-xl text-gray-300">Custom Fly-By-Wire Build</span>
                                         <a href={getDownloadLink(urls.cfbw)}>
                                             <Button className="w-40 float-right bg-blue-700 hover:bg-blue-800 font-bold">Download</Button>
                                         </a>


### PR DESCRIPTION
I fixed the capitalization of the words in downloads.

BEFORE: 
![image](https://user-images.githubusercontent.com/70278701/107420894-676b3180-6ae7-11eb-8e43-6a4538c4f5c7.png)

AFTER:
![image](https://user-images.githubusercontent.com/70278701/107420937-70f49980-6ae7-11eb-8eec-2fad6161f9ba.png)
