### PR TITLE
feat: add hover states to partners

### DIFF
--- a/src/components/app/PartnerSection.tsx
+++ b/src/components/app/PartnerSection.tsx
@@ -14,7 +14,7 @@ type PartnerProps = {
 export const PartnerImage: React.FC<ImageProps> = (props: PropsWithChildren<ImageProps>) => {
     return (
         <div className="p-8 h-full">
-            <img className="h-full w-full object-contain" src={props.src} alt=""/>
+            <img className="h-full w-full object-contain transform hover:scale-105 transition-transform duration-100" src={props.src} alt=""/>
         </div>
     );
 };


### PR DESCRIPTION
I added hover states to the partner's section.

NO HOVER:
![image](https://user-images.githubusercontent.com/70278701/107562675-22f69900-6bae-11eb-96d7-dc022d7cf78d.png)

HOVER:
![image](https://user-images.githubusercontent.com/70278701/107562706-2b4ed400-6bae-11eb-97b8-b837f67d8b29.png)

The image will slightly expand.