### PR TITLE
feat: added underlines on the tos and pp

### DIFF
--- a/src/components/app/Footer.tsx
+++ b/src/components/app/Footer.tsx
@@ -31,10 +31,10 @@ export function Footer(): JSX.Element {
                     </div>
                     <div className="text-center">
                         <div className="grid grid-cols-2 w-full sm:w-3/4 mx-auto">
-                            <a href="https://github.com/flybywiresim/manuals/blob/master/pdf/Terms%20of%20Service.pdf" target="_blank" rel="noreferrer">
+                            <a className="hover:underline" href ="https://github.com/flybywiresim/manuals/blob/master/pdf/Terms%20of%20Service.pdf" target="_blank" rel="noreferrer">
                                 <p>Terms of Service</p>
                             </a>
-                            <a href="https://github.com/flybywiresim/manuals/blob/master/pdf/Privacy%20Policy.pdf" target="_blank" rel="noreferrer">
+                            <a className="hover:underline" href="https://github.com/flybywiresim/manuals/blob/master/pdf/Privacy%20Policy.pdf" target="_blank" rel="noreferrer">
                                 <p>Privacy Policy</p>
                             </a>
                         </div>


### PR DESCRIPTION
I added hover underlines on Terms of Service and Privacy Policy.

NO HOVER:
![image](https://user-images.githubusercontent.com/70278701/107565854-2429c500-6bb2-11eb-8737-e1a70bfc9697.png)

HOVER:
![image](https://user-images.githubusercontent.com/70278701/107565876-2be96980-6bb2-11eb-8ddd-a3c3a944962f.png)
