### PR TITLE
feat: change manual button hover text color

### DIFF
--- a/src/components/app/Header.tsx
+++ b/src/components/app/Header.tsx
@@ -22,7 +22,7 @@ export function Header(): JSX.Element {
                         <Button className="w-40 bg-blue-light border-2 border-blue-light transition hover:bg-white hover:text-blue-light mr-3 font-medium">Download</Button>
                     </a>
                     <a href="https://app.gitbook.com/@flybywire-simulations/s/flybywire-simulations/" target="_blank" rel="noreferrer">
-                        <Button className="w-32 border-2 border-blue-light text-blue-light transition hover:bg-white hover:text-blue-dark font-medium">Manuals</Button>
+                        <Button className="w-32 border-2 border-blue-light text-blue-light transition hover:bg-white hover:text-blue-light font-medium">Manuals</Button>
                     </a>
                 </div>
             </Container>


### PR DESCRIPTION
I changed the hover color of the Manual button on the header.

BEFORE:

![image](https://user-images.githubusercontent.com/70278701/107566678-2b050780-6bb3-11eb-8ec8-193eb8626ac9.png)

AFTER:

![image](https://user-images.githubusercontent.com/70278701/107566714-32c4ac00-6bb3-11eb-8a25-b0f13cd45234.png)