### PR TITLE
fix: remove indentation on downloads bullets

### DIFF
--- a/src/components/app/Download.tsx
+++ b/src/components/app/Download.tsx
@@ -26,7 +26,7 @@ export function Download(): JSX.Element {
 
                                 <p className="mt-5 max-w-prose text-xl text-white">We have included many options to download our addons, you can use our custom and simple installer to always keep your products up to date, or you can download using standalone installations.</p>
                             </div>
-                            <ul data-aos="fade-up" data-aos-delay="300" className="list-disc pt-5 pl-5 text-lg text-gray-200">
+                            <ul data-aos="fade-up" data-aos-delay="300" className="list-disc -m-2 pt-5 pl-5 text-lg text-gray-200">
                                 <li className="ml-2 pl-2">Integrates seamlessly into Microsoft Flight Simulator - no external programs required</li>
                                 <li className="ml-2 pl-2">100% reversible - uninstall by deleting the addon folder</li>
                             </ul>


### PR DESCRIPTION
I removed the indent on the downloads section.

BEFORE:
![image](https://user-images.githubusercontent.com/70278701/107676439-2437cc80-6c67-11eb-8209-8b79d82e001d.png)

AFTER:
![image](https://user-images.githubusercontent.com/70278701/107676471-2dc13480-6c67-11eb-84da-53d331f795e6.png)