### PR TITLE
fix: adjusted tos and pp for mobile devices

### DIFF
--- a/src/components/app/Footer.tsx
+++ b/src/components/app/Footer.tsx
@@ -29,7 +29,7 @@ export const Footer = (): JSX.Element => (
                     <FooterIconItem icon={faYoutube} href="https://www.youtube.com/c/FlyByWireSimulations"/>
                 </div>
                 <div className="text-center">
-                    <div className="grid grid-cols-2 w-4/5 sm:w-2/3 mx-auto">
+                    <div className="grid grid-cols-2 w-3/5 mx-auto">
                         <a className="hover:underline"
                             href="https://github.com/flybywiresim/manuals/raw/master/pdf/Terms%20of%20Service.pdf"
                             target="_blank" rel="noreferrer">

--- a/src/components/app/Footer.tsx
+++ b/src/components/app/Footer.tsx
@@ -29,7 +29,7 @@ export const Footer = (): JSX.Element => (
                     <FooterIconItem icon={faYoutube} href="https://www.youtube.com/c/FlyByWireSimulations"/>
                 </div>
                 <div className="text-center">
-                    <div className="grid grid-cols-2 w-5/6 sm:w-2/3 mx-auto">
+                    <div className="grid grid-cols-2 w-4/5 sm:w-2/3 mx-auto">
                         <a className="hover:underline"
                             href="https://github.com/flybywiresim/manuals/raw/master/pdf/Terms%20of%20Service.pdf"
                             target="_blank" rel="noreferrer">


### PR DESCRIPTION
I adjusted the TOS and PP text for larger mobile devices without impacting smaller devices,

BEFORE:
![image](https://user-images.githubusercontent.com/70278701/107678993-091a8c00-6c6a-11eb-9d6b-b28e950f5324.png)

AFTER:
![image](https://user-images.githubusercontent.com/70278701/107679024-12a3f400-6c6a-11eb-9d85-85f4ac5c18d9.png)