### PR TITLE
feat: renamed nav links and learn more

### DIFF
--- a/src/components/app/Header.tsx
+++ b/src/components/app/Header.tsx
@@ -14,8 +14,8 @@ export function Header(): JSX.Element {
                     <a href="#downloadRef">
                         <Button className="w-40 bg-blue-light border-2 border-blue-light transition hover:bg-white hover:text-blue-light mr-3 font-medium">Download</Button>
                     </a>
-                    <a href="https://docs.flybywiresim.com/" target="_blank" rel="noreferrer">
-                        <Button className="w-40 border-2 border-blue-light text-blue-light transition hover:bg-white hover:text-blue-light font-medium">Documentation</Button>
+                    <a>
+                        <Button className="w-40 border-2 border-blue-light text-blue-light transition hover:bg-white hover:text-blue-light font-medium">Learn More</Button>
                     </a>
                 </div>
             </div>

--- a/src/components/app/NavLinks.tsx
+++ b/src/components/app/NavLinks.tsx
@@ -8,16 +8,12 @@ const links = [
         path: '#'
     },
     {
-        name: 'Features',
-        path: '#features'
+        name: 'Projects',
+        path: '#projects'
     },
     {
-        name: 'Pilots',
-        path: '#'
-    },
-    {
-        name: 'Developers',
-        path: '#'
+        name: 'Documentation',
+        path: 'https://docs.flybywiresim.com/'
     },
     {
         name: 'Community',


### PR DESCRIPTION
I changed the names of the nav links and renamed "Documentation" to "Learn More" as well as removing the link from Learn More and moving it to "Documentation"

BEFORE:
![image](https://user-images.githubusercontent.com/70278701/107868063-de3d5d00-6e4e-11eb-8340-1528bea88075.png)
![image](https://user-images.githubusercontent.com/70278701/107868074-f1502d00-6e4e-11eb-851f-3ab960d6570a.png)


AFTER:
![image](https://user-images.githubusercontent.com/70278701/107868070-e3021100-6e4e-11eb-883c-2699cbda0727.png)
![image](https://user-images.githubusercontent.com/70278701/107868078-f8773b00-6e4e-11eb-960f-f2ecde2cefcb.png)