### PR TITLE
feat: msfs 2020/2024 direct downloads

### DIFF
--- a/src/components/Downloads/DownloadLinks.tsx
+++ b/src/components/Downloads/DownloadLinks.tsx
@@ -1,27 +1,34 @@
 import Link from 'next/link';
-import Button from '../Button/Button';
+import Button, { ButtonProps } from '../Button/Button';
 
-type DownloadProps = {
-    stableLink?: string,
-    devLink?: string,
-    aircraft: string,
+type Version = {
+    link: string
+    parts?: number
+    theme?: ButtonProps['theme']
 
 }
 
-const downloadLinks = ({ stableLink, devLink, aircraft }: DownloadProps) => (
+type DownloadProps = {
+    addon: string,
+    versions?: Record<string, Version>,
+
+}
+
+const versionButtons = (versions: Record<string, Version>) => (
+    <span className="flex gap-x-2.5">
+        {Object.entries(versions).map(([name, version]) => (
+            <Link key={name} href={version.link}>
+                <Button theme={version.theme || 'primary'}>{name}</Button>
+            </Link>
+        ))}
+    </span>
+);
+
+const downloadLinks = ({ addon, versions }: DownloadProps) => (
     <span className="flex flex-col gap-y-1.5">
-        <h3>{aircraft}</h3>
-        {stableLink && devLink ? (
-            <>
-                <span className="flex gap-x-2.5">
-                    <Link href={stableLink}>
-                        <Button>Stable</Button>
-                    </Link>
-                    <Link href={devLink}>
-                        <Button theme="secondary">Development</Button>
-                    </Link>
-                </span>
-            </>
+        <h3>{addon}</h3>
+        {versions ? (
+            versionButtons(versions)
         ) : (
             <p>Use our installer to download.</p>
         )}

--- a/src/components/Downloads/DownloadLinks.tsx
+++ b/src/components/Downloads/DownloadLinks.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Button, { ButtonProps } from '../Button/Button';
+import React from 'react';
 
 type Version = {
     link: string
@@ -15,12 +16,38 @@ type DownloadProps = {
 }
 
 const versionButtons = (versions: Record<string, Version>) => (
-    <span className="flex gap-x-2.5">
-        {Object.entries(versions).map(([name, version]) => (
-            <Link key={name} href={version.link}>
-                <Button theme={version.theme || 'primary'}>{name}</Button>
-            </Link>
-        ))}
+    <span className="inline-grid grid-cols-[auto_auto] gap-x-2.5 gap-y-2 w-fit">
+        {Object.entries(versions).map(([name, version]) => {
+            if (version.parts) {
+                const [expanded, setExpanded] = React.useState(false);
+                const handleToggle = () => setExpanded((prev) => !prev);
+
+                const partLinks = Array.from({ length: version.parts }, (_, i) => (
+                    <Link key={i} href={`${version.link}.${(i + 1).toString().padStart(3, '0')}`}>
+                        <Button className="mb-2" theme={version.theme || 'primary'}>{`Part ${(i + 1)}`}</Button>
+                    </Link>
+                ));
+
+                return (
+                    <div key={name}>
+                        <Button onClick={handleToggle} theme={version.theme || 'primary'}>{name}</Button>
+                        <div className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                            expanded ? 'mt-4 max-h-96 opacity-100' : 'mt-0 max-h-0 opacity-0'
+                        }`}
+                        >
+                            <div className="mb-4 p-4 border-l-2 border-primary bg-gray-50 transition-transform duration-300 ease-in-out">
+                                {partLinks}
+                            </div>
+                        </div>
+                    </div>
+                )
+            }
+            return (
+                <Link key={name} href={version.link}>
+                    <Button theme={version.theme || 'primary'}>{name}</Button>
+                </Link>
+            )
+        })}
     </span>
 );
 

--- a/src/components/Downloads/DownloadLinks.tsx
+++ b/src/components/Downloads/DownloadLinks.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import Button, { ButtonProps } from '../Button/Button';
 import React from 'react';
+import Button, { ButtonProps } from '../Button/Button';
 
 type Version = {
     link: string
@@ -40,13 +40,13 @@ const versionButtons = (versions: Record<string, Version>) => (
                             </div>
                         </div>
                     </div>
-                )
+                );
             }
             return (
                 <Link key={name} href={version.link}>
                     <Button theme={version.theme || 'primary'}>{name}</Button>
                 </Link>
-            )
+            );
         })}
     </span>
 );

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -22,5 +22,9 @@ export const links: { [name: string]: string } = {
     msfs2020_a380x_stable_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/stable/A380X-stable-4K.7z',
     msfs2020_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-4K.7z',
     msfs2024_a380x_stable_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A380X-stable-4K.7z',
-    msfs2024_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-4K.7z',
+    msfs2024_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A380X-master-4K.7z',
+    msfs2020_a380x_stable_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/stable/A380X-stable-8K.7z',
+    msfs2020_a380x_dev_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-8K.7z',
+    msfs2024_a380x_stable_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A380X-stable-8K.7z',
+    msfs2024_a380x_dev_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A380X-master-8K.7z',
 };

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -19,4 +19,8 @@ export const links: { [name: string]: string } = {
     msfs2020_a32nx_dev_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A32NX-master.7z',
     msfs2024_a32nx_stable_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A32NX-stable.7z',
     msfs2024_a32nx_dev_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A32NX-master.7z',
+    msfs2020_a380x_stable_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/stable/A380X-stable-4K.7z',
+    msfs2020_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-4K.7z',
+    msfs2024_a380x_stable_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A380X-stable-4K.7z',
+    msfs2024_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-4K.7z',
 };

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -15,4 +15,8 @@ export const links: { [name: string]: string } = {
     installer_amd64_snap: 'https://flybywirecdn.com/installer/release/FlyByWire-Installer-amd64.snap',
     efb: 'https://docs.flybywiresim.com/aircraft/common/flypados3',
     pressKit: 'https://github.com/flybywiresim/branding',
+    msfs2020_a32nx_stable_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/stable/A32NX-stable.7z',
+    msfs2020_a32nx_dev_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A32NX-master.7z',
+    msfs2024_a32nx_stable_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A32NX-stable.7z',
+    msfs2024_a32nx_dev_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A32NX-master.7z',
 };

--- a/src/layouts/landing/Installer.tsx
+++ b/src/layouts/landing/Installer.tsx
@@ -18,7 +18,7 @@ const Installer = () => {
                     </div>
                 </div>
 
-                <div className="-mr-10 -mb-21 lg:col-span-2 lg:m-0 lg:grid lg:p-12">
+                <div className="-mb-21 -mr-10 lg:col-span-2 lg:m-0 lg:grid lg:p-12">
                     <img
                         alt="FlyByWire Installer screenshot"
                         src="/pages/index/installerPreview.png"

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -145,7 +145,9 @@ const Downloads: NextPage = () => {
                                 versions={
                                     {
                                         'Stable (4K)': { link: links.msfs2020_a380x_stable_4k_standalone_github },
-                                        'Development (4K)': { link: links.msfs2020_a380x_dev_4k_standalone_github, theme: 'secondary' }
+                                        'Development (4K)': { link: links.msfs2020_a380x_dev_4k_standalone_github, theme: 'secondary' },
+                                        'Stable (8K)': { link: links.msfs2020_a380x_stable_8k_standalone_github, parts: 3 },
+                                        'Development (8K)': { link: links.msfs2020_a380x_dev_8k_standalone_github, parts: 3, theme: 'secondary' },
                                     }
                                 }
                             />
@@ -158,7 +160,7 @@ const Downloads: NextPage = () => {
                                 versions={
                                     {
                                         Stable: { link: links.msfs2020_a32nx_stable_standalone_github },
-                                        Development: { link: links.msfs2020_a32nx_dev_standalone_github, theme: 'secondary' }
+                                        Development: { link: links.msfs2020_a32nx_dev_standalone_github, theme: 'secondary' },
                                     }
                                 }
                             />
@@ -167,7 +169,9 @@ const Downloads: NextPage = () => {
                                 versions={
                                     {
                                         'Stable (4K)': { link: links.msfs2024_a380x_stable_4k_standalone_github },
-                                        'Development (4K)': { link: links.msfs2024_a380x_dev_4k_standalone_github, theme: 'secondary' }
+                                        'Development (4K)': { link: links.msfs2024_a380x_dev_4k_standalone_github, theme: 'secondary' },
+                                        'Stable (8K)': { link: links.msfs2024_a380x_stable_8k_standalone_github, parts: 3 },
+                                        'Development (8K)': { link: links.msfs2024_a380x_dev_8k_standalone_github, parts: 3, theme: 'secondary' },
                                     }
                                 }
                             />

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -19,7 +19,7 @@ const Downloads: NextPage = () => {
             <Section theme="dark">
                 <Container>
                     <h4>Ready to fly?</h4>
-                    <h1>Download</h1>
+                    <h1 className="text-7xl 2xl:text-8xl">Download</h1>
                     <p className="max-w-prose">
                         We have included many options to download our addons, you
                         can use our custom and simple installer to always keep your
@@ -43,13 +43,13 @@ const Downloads: NextPage = () => {
                                 <Button
                                     label="Download for Windows"
                                     theme="primary"
-                                    className="flex-1"
+                                    className="md:min-h-0 flex-1 min-h-16"
                                     onClick={() => handleTabToggle('windows')}
                                 />
                                 <Button
                                     label="Download for Linux"
                                     theme="primary"
-                                    className="flex-1"
+                                    className="md:min-h-0 flex-1 min-h-16"
                                     onClick={() => handleTabToggle('linux')}
                                 />
                             </div>

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -124,15 +124,31 @@ const Downloads: NextPage = () => {
 
                     <div className="grow">
                         <h2>Direct Download</h2>
-                        <p className="pb-6">
+                        <p>
                             If you prefer a direct download, the following links are
                             available.
                         </p>
-                        <div className="flex flex-col lg:flex-row gap-8">
+                        <h3 className="mt-8">Microsoft Flight Simulator 2020</h3>
+                        <div className="w-full h-px bg-gray-500" />
+                        <div className="flex flex-col gap-8 lg:flex-row">
                             <DownloadLinks
                                 aircraft="A32NX"
-                                stableLink="https://github.com/flybywiresim/aircraft/releases/download/assets/stable/A32NX-stable.7z"
-                                devLink="https://github.com/flybywiresim/aircraft/releases/download/assets/master/A32NX-master.7z"
+                                stableLink={links.msfs2020_a32nx_stable_standalone_github}
+                                devLink={links.msfs2020_a32nx_dev_standalone_github}
+                            />
+                            <DownloadLinks
+                                aircraft="A380X"
+                                stableLink=""
+                                devLink=""
+                            />
+                        </div>
+                        <h3 className="mt-8">Microsoft Flight Simulator 2024</h3>
+                        <div className="w-full h-px bg-gray-500" />
+                        <div className="flex flex-col gap-8 lg:flex-row">
+                            <DownloadLinks
+                                aircraft="A32NX"
+                                stableLink={links.msfs2024_a32nx_stable_standalone_github}
+                                devLink={links.msfs2024_a32nx_dev_standalone_github}
                             />
                             <DownloadLinks
                                 aircraft="A380X"

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -132,28 +132,44 @@ const Downloads: NextPage = () => {
                         <div className="w-full h-px bg-gray-500" />
                         <div className="flex flex-col gap-8 lg:flex-row">
                             <DownloadLinks
-                                aircraft="A32NX"
-                                stableLink={links.msfs2020_a32nx_stable_standalone_github}
-                                devLink={links.msfs2020_a32nx_dev_standalone_github}
+                                addon="A32NX"
+                                versions={
+                                    {
+                                        Stable: { link: links.msfs2020_a32nx_stable_standalone_github },
+                                        Development: { link: links.msfs2020_a32nx_dev_standalone_github, theme: 'secondary' }
+                                    }
+                                }
                             />
                             <DownloadLinks
-                                aircraft="A380X"
-                                stableLink=""
-                                devLink=""
+                                addon="A380X"
+                                versions={
+                                    {
+                                        'Stable (4K)': { link: links.msfs2020_a380x_stable_4k_standalone_github },
+                                        'Development (4K)': { link: links.msfs2020_a380x_dev_4k_standalone_github, theme: 'secondary' }
+                                    }
+                                }
                             />
                         </div>
                         <h3 className="mt-8">Microsoft Flight Simulator 2024</h3>
                         <div className="w-full h-px bg-gray-500" />
                         <div className="flex flex-col gap-8 lg:flex-row">
                             <DownloadLinks
-                                aircraft="A32NX"
-                                stableLink={links.msfs2024_a32nx_stable_standalone_github}
-                                devLink={links.msfs2024_a32nx_dev_standalone_github}
+                                addon="A32NX"
+                                versions={
+                                    {
+                                        Stable: { link: links.msfs2020_a32nx_stable_standalone_github },
+                                        Development: { link: links.msfs2020_a32nx_dev_standalone_github, theme: 'secondary' }
+                                    }
+                                }
                             />
                             <DownloadLinks
-                                aircraft="A380X"
-                                stableLink=""
-                                devLink=""
+                                addon="A380X"
+                                versions={
+                                    {
+                                        'Stable (4K)': { link: links.msfs2024_a380x_stable_4k_standalone_github },
+                                        'Development (4K)': { link: links.msfs2024_a380x_dev_4k_standalone_github, theme: 'secondary' }
+                                    }
+                                }
                             />
                         </div>
                     </div>

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -136,7 +136,7 @@ const Downloads: NextPage = () => {
                                 versions={
                                     {
                                         Stable: { link: links.msfs2020_a32nx_stable_standalone_github },
-                                        Development: { link: links.msfs2020_a32nx_dev_standalone_github, theme: 'secondary' }
+                                        Development: { link: links.msfs2020_a32nx_dev_standalone_github, theme: 'secondary' },
                                     }
                                 }
                             />


### PR DESCRIPTION
Fixes #534 

## Summary of changes

- splits download links for MSFS 2020 and MSFS 2024 in accordance with https://github.com/flybywiresim/aircraft/pull/10645 and https://github.com/flybywiresim/aircraft/pull/10646
- adds A380X direct download links
- refactors download link component
- allows download of multi-part objects

## Screenshots(if applicable)
**Before:**

<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/b5e90d23-6036-4fa1-a663-aa104554ae59" />


**After:**

https://github.com/user-attachments/assets/a3758d66-e180-4502-8302-4e10e09382ff



