### PR TITLE
feat(downloads): merge MSFS2024 dev 4K and dev 8K

### DIFF
--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -24,9 +24,8 @@ export const links: { [name: string]: string } = {
     msfs2020_a380x_stable_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/stable/A380X-stable-4K.7z',
     msfs2020_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-4K.7z',
     msfs2024_a380x_stable_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A380X-stable-4K.7z',
-    msfs2024_a380x_dev_4k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A380X-master-4K.7z',
+    msfs2024_a380x_dev_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A380X-master.7z',
     msfs2020_a380x_stable_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/stable/A380X-stable-8K.7z',
     msfs2020_a380x_dev_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2020/master/A380X-master-8K.7z',
     msfs2024_a380x_stable_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/stable/A380X-stable-8K.7z',
-    msfs2024_a380x_dev_8k_standalone_github: 'https://github.com/flybywiresim/aircraft/releases/download/assets/msfs2024/master/A380X-master-8K.7z',
 };

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -169,9 +169,8 @@ const Downloads: NextPage = () => {
                                 versions={
                                     {
                                         'Stable (4K)': { link: links.msfs2024_a380x_stable_4k_standalone_github },
-                                        'Development (4K)': { link: links.msfs2024_a380x_dev_4k_standalone_github, theme: 'secondary' },
+                                        'Development': { link: links.msfs2024_a380x_dev_standalone_github, theme: 'secondary' },
                                         'Stable (8K)': { link: links.msfs2024_a380x_stable_8k_standalone_github, parts: 3 },
-                                        'Development (8K)': { link: links.msfs2024_a380x_dev_8k_standalone_github, parts: 3, theme: 'secondary' },
                                     }
                                 }
                             />


### PR DESCRIPTION

## Summary of changes
- merges MSFS 2024 development (4K) and development (8K) standalone downloads

## Screenshots(if applicable)
<img width="931" height="351" alt="image" src="https://github.com/user-attachments/assets/1e9f938e-6e1c-419e-8a72-8777ab135e03" />

requires https://github.com/flybywiresim/aircraft/pull/10758

