### PR TITLE
feat: Adding PR Build and Deploy actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Website to Cloudflare
+
+on:
+  push:
+    branches: [master, staging]
+
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build static site
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        run: |
+          npm run build
+          npm run export
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-build
+          path: out
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Pages
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: website-build
+          path: out
+
+      - name: Deploy to Cloudflare Pages
+        uses: AdrianGonz97/refined-cf-pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_PAGES_ACCOUNT_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: ${{ secrets.CLOUDFLARE_WEBSITE_PROJECT }}
+          deploymentName: ${{ github.ref_name == 'master' && 'Production' || 'Staging' }}
+          branch: ${{ github.ref_name }}
+          directory: out

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
-    name: Build static site
+    name: Build and Deploy to Cloudflare Pages
     permissions:
       contents: read
+      deployments: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,28 +34,6 @@ jobs:
         run: |
           npm run build
           npm run export
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: website-build
-          path: out
-          if-no-files-found: error
-          retention-days: 1
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    name: Deploy to Cloudflare Pages
-    permissions:
-      contents: read
-      deployments: write
-    steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: website-build
-          path: out
 
       - name: Deploy to Cloudflare Pages
         uses: AdrianGonz97/refined-cf-pages-action@v1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,44 @@
+name: PR Build Preview for Cloudflare
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    name: Build Preview Site and Upload Build Artifact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        run: |
+          npm run build
+          npm run export
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-build
+          path: out
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -1,0 +1,39 @@
+name: PR Upload Preview to Cloudflare
+
+on:
+  workflow_run:
+    workflows: ['PR Build Preview for Cloudflare']
+    types:
+      - completed
+
+permissions:
+  actions: read
+  deployments: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event.workflow_run.event == 'pull_request'
+        && github.event.workflow_run.conclusion == 'success' }}
+    name: Deploy Preview to Cloudflare Pages
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-build
+          path: out
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: AdrianGonz97/refined-cf-pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_PAGES_ACCOUNT_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: ${{ secrets.CLOUDFLARE_WEBSITE_PROJECT }}
+          deploymentName: Preview
+          directory: out

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,9 @@
 'use strict';
 
-module.exports = { trailingSlash: true };
+module.exports = {
+    trailingSlash: true,
+    // `next export` (static build for Cloudflare Pages) cannot use next/image's
+    // default optimization loader, which needs a running server. Disabling it
+    // emits plain <img> tags; Cloudflare serves the images as static assets.
+    images: { unoptimized: true },
+};


### PR DESCRIPTION
Similar to flybywiresim/docs#1056

## Summary

Uses https://github.com/marketplace/actions/refined-cloudflare-pages-action for building and deploying PR Previews to Cloudflare pages, as well as building master and staging branches for better control.

### Setup

Requires a few new secrets:
* `CLOUDFLARE_PAGES_API_TOKEN` - Specific API Token with access to editing Cloudflare Pages for the account. (NOTE: Already exists)
* `CLOUDFLARE_PAGES_ACCOUNT_ID` - API Account ID for Cloudflare Pages, this could be the same as the main account, but might be good to split up in case we ever need to have flexibility. (NOTE: Already exists)
* `CLOUDFLARE_WEBSITE_PROJECT` - The Pages project in Cloudflare for the docs site specifically. (NOTE: Already exists)

For better control of production and staging builds, this also covers building and deploying the master and staging branches, allowing better control than the CloudFlare building solution. This requires CloudFlare configuration to be changed to not auto-build on any branches (already set up as builds were broken). This will show in CloudFlare as "Builds paused", but that is expected and acceptable.


### Functionality for PR

This is a two-stepped approach so that PRs do not need access to secrets (fork PRs have no access to secrets of the main repo):
1. PR Build & Upload - This builds and uploads an archive of the build locally for the PR itself. This is triggered by opening or syncing a PR (pushing to it)
2. PR Deploy - This runs after the PR Build, and runs inside the secure context of the main repo, with no visibility into the secrets by the PR or PR Repo. It takes the archive and creates a Preview deployment for the PR (name is `<repo-owner>-<branch>.<project>.pages.dev`. 
3. The action creates or updates (if new commits) a comment on the PR with the Preview deployment link after build

### Functionality for master/staging

A single workflow with two separate steps to avoid exposing secrets to any npm build / export code. 

### Proof of concept

* Mirrored website repo: https://github.com/pdellaert/test-fbw-website
  * Master Deployed on https://test-fbw-website.pages.dev/
  * Staging Deployed on https://91127ed6.test-fbw-website.pages.dev/
  * branch PR - pdellaert/test-fbw-website#1

### Note

This no longer requires #554 to be addressed, as we are no longer depending on CloudFlare builds.